### PR TITLE
Fix secondary-menu focus styles

### DIFF
--- a/sites/all/themes/newhopeks/css/style.css
+++ b/sites/all/themes/newhopeks/css/style.css
@@ -6879,7 +6879,7 @@ table > tbody > tr:hover {
   line-height: inherit;
 }
 .header .navbar-main .navbar-collapse .top-bar .secondary-menu li a:hover,
-.header .navbar-main .navbar-collapse .top-bar .secondary-menu li a:active {
+.header .navbar-main .navbar-collapse .top-bar .secondary-menu li a:focus {
   background-color: transparent;
   text-decoration: underline;
 }

--- a/sites/all/themes/newhopeks/less/page.less
+++ b/sites/all/themes/newhopeks/less/page.less
@@ -221,7 +221,7 @@
 	                        line-height: inherit;
 
 	                        &:hover,
-	                        &:active {
+	                        &:focus {
 	                            background-color: transparent;
 	                            text-decoration: underline;
 	                        }


### PR DESCRIPTION
- [x] #183 Top nav items change to white blocks when in focus state